### PR TITLE
Fixed ch4 'write' example wrong handler

### DIFF
--- a/Chapter_4_Processing_Requests/write/server.go
+++ b/Chapter_4_Processing_Requests/write/server.go
@@ -46,6 +46,6 @@ func main() {
 	http.HandleFunc("/write", writeExample)
 	http.HandleFunc("/writeheader", writeHeaderExample)
 	http.HandleFunc("/redirect", headerExample)
-	http.HandleFunc("/json", headerExample)
+	http.HandleFunc("/json", jsonExample)
 	server.ListenAndServe()
 }


### PR DESCRIPTION
@sausheong the json path was redirecting to Google :)
