### PR TITLE
Chapter_6_Storing_Data/gorm_store/store.go

### DIFF
--- a/Chapter_6_Storing_Data/gorm_store/store.go
+++ b/Chapter_6_Storing_Data/gorm_store/store.go
@@ -23,7 +23,7 @@ type Comment struct {
 	CreatedAt time.Time
 }
 
-var Db gorm.DB
+var Db *gorm.DB
 
 // connect to the Db
 func init() {


### PR DESCRIPTION
var Db gorm.DB 
causing programming errors: cannot assign *gorm.DB to Db (type gorm.DB) in multiple assignment