### PR TITLE
Fixes incorrect bits 7 and 6 should be set to 1 and 0 respectively.

### DIFF
--- a/Chapter_2_Go_ChitChat/chitchat/data/data.go
+++ b/Chapter_2_Go_ChitChat/chitchat/data/data.go
@@ -29,8 +29,11 @@ func createUUID() (uuid string) {
 		log.Fatalln("Cannot generate UUID", err)
 	}
 
-	// 0x40 is reserved variant from RFC 4122
-	u[8] = (u[8] | 0x40) & 0x7F
+	// From RFC 4122. Set the two most significant bits
+	// (bits 6 and 7) of the clock_seq_hi_and_reserved to
+	// zero and one, respectively.
+	u[8] = (u[8] & 0x3f) | 0x80
+
 	// Set the four most significant bits (bits 12 through 15) of the
 	// time_hi_and_version field to the 4-bit version number.
 	u[6] = (u[6] & 0xF) | (0x4 << 4)


### PR DESCRIPTION
Bit pattern for the 9th byte should be:

```
7 6 5 4 3 2 1 0
+-+-+-+-+-+-+-+-+
|1|0| | | | | | |
+-+-+-+-+-+-+-+-+
```

And _not_ the following:
```
7 6 5 4 3 2 1 0
+-+-+-+-+-+-+-+-+
|0|1| | | | | | |
+-+-+-+-+-+-+-+-+
```
https://www.cryptosys.net/pki/uuid-rfc4122.html#note1